### PR TITLE
ツール/オンラインコンパイラ: GDB Onlineの追加

### DIFF
--- a/docs/tools/onlinecompilers.md
+++ b/docs/tools/onlinecompilers.md
@@ -13,6 +13,7 @@ C++ プログラムのコンパイル・実行ができる Web サイトです�
 | [paiza.io](https://paiza.io/ja/projects/new?language=cpp) | Clang 6.0.0                      | :fa-check:   |                  | :fa-check:   | :fa-check: |
 | [Ideone](https://ideone.com/)                             | gcc 6.3.0                        | :fa-check:   |                  |              | :fa-check: |
 | [C++ Shell](http://cpp.sh/)                               | gcc 4.9.2                        |              | :fa-check:       |              | :fa-check: |
+| [GDB Online](https://www.onlinegdb.com/)                  | gcc 7.3.0                        | :fa-check:   | :fa-check:       | :fa-check:   | :fa-check: |
 
 ## C++ Insights: ソース → ソース変換
 [C++ Insights](https://cppinsights.io/) は、ラムダ式、range-based for, 構造化束縛などで何が起こっているのかを、プログラムを単純なソースコードに分解することで可視化するオンラインのツールです。  

--- a/docs/tools/onlinecompilers.md
+++ b/docs/tools/onlinecompilers.md
@@ -11,9 +11,9 @@ C++ プログラムのコンパイル・実行ができる Web サイトです�
 | [Wandbox](https://wandbox.org/)                           | gcc HEAD 9.0.1, Clang HEAD 9.0.0 | :fa-check:   |                  | :fa-check:   | :fa-check: |
 | [repl.it](https://repl.it/languages/cpp)                  | Clang 7.0.0                      | :fa-check:   | :fa-check:       | :fa-check:   | :fa-check: |
 | [paiza.io](https://paiza.io/ja/projects/new?language=cpp) | Clang 6.0.0                      | :fa-check:   |                  | :fa-check:   | :fa-check: |
+| [GDB Online](https://www.onlinegdb.com/)                  | gcc 7.3.0                        | :fa-check:   | :fa-check:       | :fa-check:   | :fa-check: |
 | [Ideone](https://ideone.com/)                             | gcc 6.3.0                        | :fa-check:   |                  |              | :fa-check: |
 | [C++ Shell](http://cpp.sh/)                               | gcc 4.9.2                        |              | :fa-check:       |              | :fa-check: |
-| [GDB Online](https://www.onlinegdb.com/)                  | gcc 7.3.0                        | :fa-check:   | :fa-check:       | :fa-check:   | :fa-check: |
 
 ## C++ Insights: ソース → ソース変換
 [C++ Insights](https://cppinsights.io/) は、ラムダ式、range-based for, 構造化束縛などで何が起こっているのかを、プログラムを単純なソースコードに分解することで可視化するオンラインのツールです。  

--- a/docs/tools/onlinecompilers.md
+++ b/docs/tools/onlinecompilers.md
@@ -6,13 +6,13 @@ description: C++ プログラムのコンパイル・実行ができる Web サ�
 
 C++ プログラムのコンパイル・実行ができる Web サイトです。
 
-|                                                           | コンパイラ                        | 日本語入出力 | インタラクティブ | 複数ファイル | Share     |
-| --------------------------------------------------------- | -------------------------------- | ----------- | -------------- | ----------- | ---------- |
-| [Wandbox](https://wandbox.org/)                           | gcc HEAD 9.0.1, Clang HEAD 9.0.0 | :fa-check:  |                | :fa-check:  | :fa-check: |
-| [repl.it](https://repl.it/languages/cpp)                  | Clang 7.0.0                      | :fa-check:  | :fa-check:     | :fa-check:  | :fa-check: |
-| [paiza.io](https://paiza.io/ja/projects/new?language=cpp) | Clang 6.0.0                      | :fa-check:  |                | :fa-check:  | :fa-check: |
-| [Ideone](https://ideone.com/)                             | gcc 6.3.0                        | :fa-check:  |                |             | :fa-check: |
-| [C++ Shell](http://cpp.sh/)                               | gcc 4.9.2                        |             | :fa-check:     |             | :fa-check: |
+|                                                           | コンパイラ                       | 日本語入出力 | インタラクティブ | 複数ファイル | Share      |
+| --------------------------------------------------------- | -------------------------------- | ------------ | ---------------- | ------------ | ---------- |
+| [Wandbox](https://wandbox.org/)                           | gcc HEAD 9.0.1, Clang HEAD 9.0.0 | :fa-check:   |                  | :fa-check:   | :fa-check: |
+| [repl.it](https://repl.it/languages/cpp)                  | Clang 7.0.0                      | :fa-check:   | :fa-check:       | :fa-check:   | :fa-check: |
+| [paiza.io](https://paiza.io/ja/projects/new?language=cpp) | Clang 6.0.0                      | :fa-check:   |                  | :fa-check:   | :fa-check: |
+| [Ideone](https://ideone.com/)                             | gcc 6.3.0                        | :fa-check:   |                  |              | :fa-check: |
+| [C++ Shell](http://cpp.sh/)                               | gcc 4.9.2                        |              | :fa-check:       |              | :fa-check: |
 
 ## C++ Insights: ソース → ソース変換
 [C++ Insights](https://cppinsights.io/) は、ラムダ式、range-based for, 構造化束縛などで何が起こっているのかを、プログラムを単純なソースコードに分解することで可視化するオンラインのツールです。  


### PR DESCRIPTION
[GDB Online](https://www.onlinegdb.com/) という，簡易なWebIDEを追加．
コードエディタ上では補完候補が表示され，インタラクティブな標準入力やGDBが使える．
複数ファイルの使用やコードフォーマット，permalink・ローカルへのダウンロードなどの機能も充実．試してないけどGithubへのファイルエクスポートもできるっぽい？
ただ，補完候補については何に基づいて表示しているのかよくわからない… (`endl` は候補に挙がらないがローカル変数はちゃんと挙がる，など)

公式のFAQにはgcc 5.4.1が入っていると書いてあるが， `__VERSION__` 吐かせたら `7.3.0` と出たし構造化束縛が使えるので一応7.3.0と書いています(たぶんFAQが古いまま)

ただのオンラインコンパイラよりはちょっと便利機能が多いので，そのへんの追記が必要なら対応します．