### PR TITLE
Fix code block syntax

### DIFF
--- a/docs/standardization/cppx.md
+++ b/docs/standardization/cppx.md
@@ -94,7 +94,7 @@ inspect constexpr_opt (init-statement_opt condition) trailing-return-type_opt
 		404 => { std::cout << "Not Found\n" }
 		__  => { std::cout << "don't care\n" } // __ はワイルドカードパターン
 	};
-```
+	```
 
 ### 文字列のマッチング
 
@@ -148,7 +148,7 @@ inspect constexpr_opt (init-statement_opt condition) trailing-return-type_opt
 	{
 		std::cout << x << ", " << y << '\n';
 	}
-```
+	```
 
 === "提案"
 


### PR DESCRIPTION
以下の二箇所でレイアウトが崩れていたので修正しました。

## 修正前

### 1. https://cppmap.github.io/standardization/cppx/#_5
![image](https://user-images.githubusercontent.com/7816696/138724431-12e3d783-70fd-477d-ba8d-7d55c8979d9b.png)

### 2. https://cppmap.github.io/standardization/cppx/#tuples
![image](https://user-images.githubusercontent.com/7816696/138724577-e0f092c2-ae50-40fd-8e8e-010d334bbadd.png)
