### PR TITLE
Fix typo

### DIFF
--- a/docs/standardization/cppx.md
+++ b/docs/standardization/cppx.md
@@ -199,7 +199,7 @@ inspect constexpr_opt (init-statement_opt condition) trailing-return-type_opt
 		{
 			<int> i   => { std::cout << "int: " << i << '\n'; }
 			<float> f => { std::cout << "float: " << f << '\n'; }
-		}
+		};
 	};
 	```
 
@@ -257,7 +257,7 @@ inspect constexpr_opt (init-statement_opt condition) trailing-return-type_opt
 		{
 			<Circle>	[r]		=> std::numbers::pi * r * r;
 			<Rectangle>	[w, h]	=> w * h;
-		}
+		};
 	};
 	```
 


### PR DESCRIPTION
`inspect` 式のセミコロンのつけ忘れを修正しました。