### PR TITLE
ツール: リンターの追加

### DIFF
--- a/docs/tools/linter.md
+++ b/docs/tools/linter.md
@@ -1,0 +1,13 @@
+description: C++ リンターの紹介
+
+# C++ リンター
+
+## Clang-Tidy
+- https://clang.llvm.org/extra/clang-tidy/
+
+## cpplint
+- https://github.com/cpplint/cpplint
+
+## Cppcheck
+- https://cppcheck.sourceforge.io/
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - C++ コンパイラ: tools/compilers.md
     - C++ パッケージマネージャ: tools/package-manager.md
     - C++ コードフォーマッタ: tools/code-formatter.md
+    - C++ リンター: tools/linter.md
     - C++ プロジェクトテンプレート: tools/project-template.md
     - C++ 用 .gitignore: tools/gitignore.md
   - 貢献:


### PR DESCRIPTION
一旦、[C++ コンパイラ](https://cppmap.github.io/tools/compilers/)ページと同様に、リストアップのみをしてみました。
「パッケージマネージャ」や「コードフォーマッタ」では、末尾に長音符号（ー）が付いていないように統一されているようですが、「リンター」を「リンタ」にしてしまうと違和感があるので、長音符号を付けたままにしています。